### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 # .github/workflows/test.yml
 name: Test
+permissions:
+  contents: read
+  id-token: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/h13/instapaper-to-podcast/security/code-scanning/1](https://github.com/h13/instapaper-to-podcast/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient for most steps. Additionally, the `id-token: write` permission is required for the `codecov/codecov-action` step to upload coverage reports securely. These permissions will be explicitly defined to ensure the workflow operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
